### PR TITLE
Adjust journal names so not abbreviated

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,7 +1,7 @@
 @article{intravaia18,
   title = {Quantum rolling friction},
   author = {Intravaia, F. and Oelschl\"ager, M. and Reiche, D. and Dalvit, D. A. R. and Busch, K.},
-  journal = {Phys. Rev. Lett.},
+  journal = {Physical Review Letters},
   volume = {123},
   issue = {12},
   pages = {120401},
@@ -15,7 +15,7 @@
 
 @Article{reiche2020a,
   author    = {Reiche, D. and Intravaia, F. and Hsiang, J.-T. and Busch, K. and Hu, B.-L.},
-  journal   = {Phys. Rev. A},
+  journal   = {Physical Review A},
   title     = {Nonequilibrium thermodynamics of quantum friction},
   year      = {2020},
   month     = {Nov},
@@ -120,7 +120,7 @@
   pages = {042114},
   doi = {10.1103/PhysRevA.94.042114},
   file = {/home/marty/Zotero/storage/GF7QXTDE/Intravaia et al_2016_Non-Markovianity in atom-surface dispersion forces.pdf},
-  journal = {Phys. Rev. A},
+  journal = {Physical Review A},
   keywords = {_tablet},
   number = {4}
 }
@@ -128,7 +128,7 @@
 @Article{intravaia2016,
   Title                    = {Failure of local thermal equilibrium in quantum friction},
   Author                   = {Intravaia, F. and Behunin, R. O. and Henkel, C. and Busch, K. and Dalvit, D. A. R.},
-  Journal                  = {Phys. Rev. Lett.},
+  Journal                  = {Physical Review Letters},
   Year                     = {2016},
 
   Month                    = {Sep},
@@ -160,7 +160,7 @@
   pages = {050101},
   doi = {10.1103/PhysRevA.89.050101},
   file = {/home/marty/Zotero/storage/7B7VZH65/Intravaia et al_2014_Quantum friction and fluctuation theorems.pdf;/home/marty/Zotero/storage/UMI5ZGS7/Intravaia et al_2014_Quantum friction and fluctuation theorems.pdf},
-  journal = {Phys. Rev. A},
+  journal = {Physical Review A},
   keywords = {_tablet},
   number = {5}
 }
@@ -202,7 +202,7 @@
 @Article{mkrtchian2003,
   author    = {Mkrtchian, Vanik and Parsegian, V. Adrian and Podgornik, Rudi and Saslow, Wayne M.},
   title     = {Universal thermal radiation drag on neutral objects},
-  journal   = {Phys. Rev. Lett.},
+  journal   = {Physical Review Letters},
   year      = {2003},
   volume    = {91},
   pages     = {220801},
@@ -299,10 +299,10 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
 
 @Article{oelschlaeger2021,
   author     = {Oelschläger, M. and Reiche, D. and Egerland, C. H. and Busch, K. and Intravaia, F.},
-  journal    = {arXiv:2110.13635 [quant-ph]},
+  journal    = {Physical Review A},
   title      = {Electromagnetic viscosity in complex structured environments: from blackbody to quantum friction
 },
-  year       = {20212},
+  year       = {2022},
   month      = nov,
   abstract   = {We investigate the nonconservative open-system dynamics of an atom in a generic complex structured electromagnetic environment at temperature \$T\$. In such systems, when the atom moves along a translation-invariant axis of the environment, a frictional force acts on the particle. The effective viscosity due to friction results from the nonequilibrium interaction with the fluctuating (quantum) electromagnetic field, which effectively sets a privileged reference frame. We study the impact of both quantum or thermal fluctuations on the interaction and highlight how they induce qualitatively different types of viscosity, i.e. quantum and black-body friction. To this end, we develop a self-consistent non-Markovian description that contains the latter as special cases. In particular, we show how the interplay between the nonequilibrium dynamics, the quantum and the thermal properties of the radiation, as well as the confinement of light at the vacuum-material interface is responsible for several interesting and intriguing features. Our analyses is relevant for a future experimental test of noncontact friction and the resulting electromagnetic viscosity.},
   keywords   = {Quantum Physics},
@@ -315,7 +315,7 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
 @Article{reiche2019,
   author    = {D. Reiche and M. Oelschl\"{a}ger and K. Busch and F. Intravaia},
   title     = {Extended hydrodynamic description for nonequilibrium atom-surface interactions},
-  journal   = {J. Opt. Soc. Am. B},
+  journal   = {Journal of the Optical Society of America B},
   year      = {2019},
   volume    = {36},
   number    = {4},
@@ -426,7 +426,7 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
   pages = {042902},
   doi = {10.1103/PhysRevA.80.042902},
   file = {/home/marty/Zotero/storage/99DIIT5F/Scheel2009.pdf},
-  journal = {Phys. Rev. A},
+  journal = {Physical Review A},
   number = {4}
 }
 
@@ -455,7 +455,7 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
   pages = {115419},
   doi = {10.1103/PhysRevB.65.115419},
   file = {/home/marty/Zotero/storage/YVZRWLVY/Volokitin2002.pdf},
-  journal = {Phys. Rev. B},
+  journal = {Physical Review B},
   number = {11}
 }
 
@@ -478,7 +478,7 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
 @Article{volokitin2011,
   author    = {Volokitin, A. I. and Persson, B. N. J.},
   title     = {Quantum friction},
-  journal   = {Phys. Rev. Lett.},
+  journal   = {Physical Review Letters},
   year      = {2011},
   volume    = {106},
   pages     = {094502},
@@ -494,7 +494,7 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
 @Article{volokitin2007,
   Title                    = {Near-field radiative heat transfer and noncontact friction},
   Author                   = {Volokitin, A. I. and Persson, B. N. J.},
-  Journal                  = {Rev. Mod. Phys.},
+  Journal                  = {Review Modern Physics},
   Year                     = {2007},
 
   Month                    = {Oct},
@@ -534,7 +534,7 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
   pages = {360--372},
   doi = {10.1103/PhysRev.73.360},
   file = {/home/marty/Zotero/storage/5CGKAHQH/Casimir_Polder_1948_The Influence of Retardation on the London-van der Waals Forces.pdf},
-  journal = {Phys. Rev.},
+  journal = {Physical Review},
   keywords = {_tablet},
   number = {4}
 }
@@ -550,7 +550,7 @@ Program title: Meep Catalogue identifier: AEFU\_v1\_0 Program summary URL:: http
 @Article{ford1985,
   Title                    = {Quantum oscillator in a blackbody radiation field},
   Author                   = {Ford, G. W. and Lewis, J. T. and O'Connell, R. F.},
-  Journal                  = {Phys. Rev. Lett.},
+  Journal                  = {Physical Review Letters},
   Year                     = {1985},
 
   Month                    = {Nov},


### PR DESCRIPTION
Inconsistent references, with mixture of abbreviated and non-abbreviated journal names. Fixed in this commit.